### PR TITLE
Fix reading from symlinks

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ Flatiron.prototype.write = function (readTree, destDir) {
           entries = fs.readdirSync(srcDir);
 
       Array.prototype.forEach.call(entries, function(entry) {
-        if (fs.lstatSync(path.join(srcDir, entry)).isDirectory())
+        if (fs.statSync(path.join(srcDir, entry)).isDirectory())
           obj[entry] = readDirectory(path.join(srcDir, entry));
         else
           obj[_this.options.trimExtensions ? entry.split(".")[0] : entry] =


### PR DESCRIPTION
When using this add-on as a dependency of ember-code-snippet, I received the following error when the app was built:

> EISDIR: illegal operation on a directory, read

After some research I stumbled into [a comment by @hjdivad](https://github.com/ember-cli/ember-cli/issues/6981#issuecomment-296618333) that suggested the problem might be that a symlink to a directory is not considered a directory by node's `isDirectory` and suggested that the fix would be just replacing `fs.lstatSync` with `fs.statSync`.

I did that and it fixed the build.

I'd appreciate if you could merge the fix and release a new version.

Thank you.